### PR TITLE
Simplify usage of HttpRobot and RemoteRobot services

### DIFF
--- a/software/poppy/creatures/services_launcher.py
+++ b/software/poppy/creatures/services_launcher.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import socket
+import argparse
+import time
+
+from poppy.creatures import installed_poppy_creatures
+from .abstractcreature import AbstractPoppyCreature
+
+
+def find_local_ip():
+    # This is rather obscure...
+    # go see here: http://stackoverflow.com/questions/166506/
+    return [(s.connect(('8.8.8.8', 80)), s.getsockname()[0], s.close())
+            for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('creature', type=str,
+                        choices=installed_poppy_creatures.keys())
+    parser.add_argument('--vrep', action='store_true')
+    parser.add_argument('--snap', action='store_true')
+    parser.add_argument('--http', action='store_true')
+    parser.add_argument('--remote', action='store_true')
+    args = parser.parse_args()
+
+    poppy_args = {
+        'use_snap': args.snap,
+        'use_http': args.http,
+        'use_remote': args.remote
+    }
+    if any([args.snap, args.http, args.remote]):
+        if args.vrep:
+            poppy_args['simulator'] = 'vrep'
+
+        poppy = installed_poppy_creatures[args.creature](**poppy_args)
+        AbstractPoppyCreature.start_background_services(poppy)
+
+        print("Services started")
+        try:
+            while(True):
+                time.sleep(1)
+        except KeyboardInterrupt:
+            print("Bye bye!")
+    else:
+        print("No service specified")
+if __name__ == '__main__':
+    main()

--- a/software/setup.py
+++ b/software/setup.py
@@ -28,11 +28,12 @@ setup(name='poppy-creature',
       zip_safe=False,
 
       entry_points={
-            'console_scripts': [
-                'poppy-shell=poppy.creatures.poppy_sim:main',
-                'poppy-snap=poppy.creatures.snap_launcher:main',
-            ],
-        },
+          'console_scripts': [
+              'poppy-shell=poppy.creatures.poppy_sim:main',
+              'poppy-snap=poppy.creatures.snap_launcher:main',
+              'poppy-services=poppy.creatures.services_launcher:main',
+          ],
+      },
 
       author='Pierre Rouanet, Matthieu Lapeyre',
       author_email='pierre.rouanet@gmail.com',


### PR DESCRIPTION
Add the ability to 'use_http' and 'use_remote' by adding arguments similar to those for 'use_snap'. 
Add the ability to start those servers as background threads.
Add a services launcher.
