### PR TITLE
Fix camelcase_to_underscore issue

### DIFF
--- a/software/poppy/creatures/abstractcreature.py
+++ b/software/poppy/creatures/abstractcreature.py
@@ -25,8 +25,7 @@ class DeamonThread(Thread):
 
 
 def camelcase_to_underscore(name):
-    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+    return re.sub('([a-z])([A-Z0-9])', r'\1_\2', name).lower()
 
 
 class AbstractPoppyCreature(Robot):


### PR DESCRIPTION
This fix poppy-project/poppy-4dof-arm-mini#2

```
In [34]: e="PoppyDof4ArmMini"

In [35]: camelcase_to_underscore(e)
Out[35]: 'poppy_dof_4arm_mini'

In [36]: f="Poppy4DofArmMini"

In [37]: camelcase_to_underscore(f)
Out[37]: 'poppy_4dof_arm_mini'
```

@pierre-rouanet I don't understand the utility of `s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)`
