### PR TITLE
Add tornado as a required dependancy

### DIFF
--- a/software/conda.recipe/meta.yaml
+++ b/software/conda.recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - setuptools
     - pypot >2.11
     - bottle
+    - tornado
     - ikpy >=2
 
   run:
@@ -31,6 +32,7 @@ requirements:
     - ipython
     - pypot >2.11
     - bottle
+    - tornado
     - ikpy >=2
 
 test:

--- a/software/setup.py
+++ b/software/setup.py
@@ -18,7 +18,7 @@ setup(name='poppy-creature',
       version=version(),
       packages=find_packages(),
 
-      install_requires=['pypot>=2.11.0', 'bottle', 'ikpy>=2.0'],
+      install_requires=['pypot>=2.11.0', 'bottle', 'tornado' 'ikpy>=2.0'],
 
       include_package_data=True,
       exclude_package_data={'': ['README.md', '.gitignore']},


### PR DESCRIPTION
For an unknown raison, http-server key of pypot (pypot[http-server]) have been deleted of the requirements of popy-creature.
However, for a very odd raison I didn't manage to install tornado with a pip install pypot[http-server], so I added it in the requirements.
Any ideas @pierre-rouanet ?
