### PR TITLE
Add a kinematic_chains attribute the robot

### DIFF
--- a/software/poppy/creatures/abstractcreature.py
+++ b/software/poppy/creatures/abstractcreature.py
@@ -148,6 +148,8 @@ class AbstractPoppyCreature(Robot):
             poppy_creature.remote = RemoteRobotServer(poppy_creature, remote_host, remote_port)
             print('RemoteRobotServer is now running on: http://{}:{}\n'.format(remote_host, remote_port))
 
+        poppy_creature.kinematic_chains = []
+
         cls.setup(poppy_creature)
 
         if start_background_services:

--- a/software/poppy/creatures/ik.py
+++ b/software/poppy/creatures/ik.py
@@ -77,7 +77,7 @@ class IKChain(Chain):
         self._goto(M, duration, wait, accurate)
 
     def __repr__(self):
-        return "Kinematic chain name={} motors={}".format(self.name, self.motors)
+        return "Kinematic chain name={}".format(self.name)
 
     def _goto(self, pose, duration, wait, accurate):
         """ Goes to a given cartesian pose.

--- a/software/poppy/creatures/ik.py
+++ b/software/poppy/creatures/ik.py
@@ -12,7 +12,8 @@ class IKChain(Chain):
     """
     @classmethod
     def from_poppy_creature(cls, poppy, motors, passiv, tip,
-                            reversed_motors=[], name="chain"):
+                            reversed_motors=[],
+                            name='chain'):
         """ Creates an kinematic chain from motors of a Poppy Creature.
 
             :param poppy: PoppyCreature used
@@ -77,7 +78,7 @@ class IKChain(Chain):
         self._goto(M, duration, wait, accurate)
 
     def __repr__(self):
-        return "Kinematic chain name={}".format(self.name)
+        return 'Kinematic chain "{}"'.format(self.name)
 
     def _goto(self, pose, duration, wait, accurate):
         """ Goes to a given cartesian pose.

--- a/software/poppy/creatures/ik.py
+++ b/software/poppy/creatures/ik.py
@@ -31,7 +31,8 @@ class IKChain(Chain):
         chain = cls.from_urdf_file(poppy.urdf_file,
                                    base_elements=chain_elements,
                                    last_link_vector=tip,
-                                   active_links_mask=activ)
+                                   active_links_mask=activ,
+                                   name=name)
 
         chain.motors = [getattr(poppy, l.name) for l in chain.links[1:-1]]
 

--- a/software/poppy/creatures/ik.py
+++ b/software/poppy/creatures/ik.py
@@ -128,5 +128,8 @@ class IKChain(Chain):
                 for j, m in zip(joints, self.motors)]
 
     def register(self, robot):
+        if hasattr(robot, self.name):
+            raise AttributeError('Robot has already an attribute named {}'.format(self.name))
+
         setattr(robot, self.name, self)
         robot.kinematic_chains.append(self)

--- a/software/poppy/creatures/ik.py
+++ b/software/poppy/creatures/ik.py
@@ -12,7 +12,7 @@ class IKChain(Chain):
     """
     @classmethod
     def from_poppy_creature(cls, poppy, motors, passiv, tip,
-                            reversed_motors=[]):
+                            reversed_motors=[], name="chain"):
         """ Creates an kinematic chain from motors of a Poppy Creature.
 
             :param poppy: PoppyCreature used
@@ -20,6 +20,7 @@ class IKChain(Chain):
             :param list passiv: list of motors which are passiv in the chain (they will not move)
             :param list tip: [x, y, z] translation of the tip of the chain (in meters)
             :param list reversed_motors: list of motors that should be manually reversed (due to a problem in the URDF?)
+            :param string name: The name of the chain
 
         """
         chain_elements = get_chain_from_joints(poppy.urdf_file,
@@ -74,6 +75,9 @@ class IKChain(Chain):
         M[:3, 3] = position
         self._goto(M, duration, wait, accurate)
 
+    def __repr__(self):
+        return "Kinematic chain name={} motors={}".format(self.name, self.motors)
+
     def _goto(self, pose, duration, wait, accurate):
         """ Goes to a given cartesian pose.
 
@@ -120,3 +124,7 @@ class IKChain(Chain):
 
         return [(j * (1 if m.direct else -1)) - m.offset
                 for j, m in zip(joints, self.motors)]
+
+    def register(self, robot):
+        setattr(robot, self.name, self)
+        robot.kinematic_chains.append(self)

--- a/software/setup.py
+++ b/software/setup.py
@@ -18,7 +18,7 @@ setup(name='poppy-creature',
       version=version(),
       packages=find_packages(),
 
-      install_requires=['pypot>=2.11.0', 'bottle', 'tornado', 'ikpy>=2.2'],
+      install_requires=['pypot>=2.11.0', 'bottle', 'tornado', 'ikpy>=2.2.1'],
 
       include_package_data=True,
       exclude_package_data={'': ['README.md', '.gitignore']},

--- a/software/setup.py
+++ b/software/setup.py
@@ -18,7 +18,7 @@ setup(name='poppy-creature',
       version=version(),
       packages=find_packages(),
 
-      install_requires=['pypot>=2.11.0', 'bottle', 'tornado', 'ikpy>=2.0'],
+      install_requires=['pypot>=2.11.0', 'bottle', 'tornado', 'ikpy>=2.2'],
 
       include_package_data=True,
       exclude_package_data={'': ['README.md', '.gitignore']},


### PR DESCRIPTION
Hi everyone,
This PR adds a `kinematic_chains` attribute to the creatures. It can be used in a way similar to the `motors` attribute of the Robot object.
For example, with the ErgoJr :

```
>>> poppy.kinematic_chains
[Kinematic chain name=chain motors=[<DxlMotor name=m1 id=1 pos=2.2>, <DxlMotor name=m2 id=2 pos=1.5>, <DxlMotor name=m3 id=3 pos=-0.0>, <DxlMotor name=m4 id=4 pos=-0.2>, <DxlMotor name=m5 id=5 pos=0.2>, <DxlMotor name=m6 id=6 pos=-0.0>]]
>>> poppy.chain.links
[Link name=Base link, Link name=m1, Link name=m2, Link name=m3, Link name=m4, Link name=m5, Link name=m6, Link name=last_joint]
```

For now, the chain should be registered as part as a robot using the `register` method. 
