### PR TITLE
Retries to instantiate the robot until success (or max trials reached).

### DIFF
--- a/software/poppy/creatures/abstractcreature.py
+++ b/software/poppy/creatures/abstractcreature.py
@@ -12,6 +12,7 @@ from pypot.server.snap import SnapRobotServer, find_local_ip
 
 logger = logging.getLogger(__name__)
 SERVICE_THREADS = {}
+MAX_SETUP_TRIALS = 10
 
 
 class DeamonThread(Thread):
@@ -115,10 +116,13 @@ class AbstractPoppyCreature(Robot):
             poppy_creature.simulated = True
 
         else:
-            try:
-                poppy_creature = from_json(config, sync, **extra)
-            except IndexError as e:
-                raise IOError('Connection to the robot failed! {}'.format(str(e)))
+            for _ in range(MAX_SETUP_TRIALS):
+                try:
+                    poppy_creature = from_json(config, sync, **extra)
+                    print('Init successful')
+                    break
+                except Exception as e:
+                    print('Fail: {}'.format(str(e)))
             poppy_creature.simulated = False
 
         with open(config) as f:


### PR DESCRIPTION
Continuing on https://github.com/poppy-project/pypot/commit/c4f168b2d655075f374bb747e1123917900db217 I suggest we modify the setup of a PoppyCreature so it retries until the setup actually works. 

It will give something like:

``` python
jr = PoppyErgoJr()
Fail: Could not find the motors (1, 2, 3, 4, 5, 6) on bus /dev/ttyACM0.
Fail: Could not find the motors (1, 2, 3, 4, 5, 6) on bus /dev/ttyACM0.
Fail: Could not find the motors (1, 2, 3, 4, 5, 6) on bus /dev/ttyACM0.
Fail: Could not find the motors (1, 2, 3, 4, 5, 6) on bus /dev/ttyACM0.
Init successful.
```

It's not really clean but having to restart your python console until it actually manages to connect to the robot can be rather annoying 😠 

What do you say @show0k @damiencaselli @matthieu-lapeyre (and others) ?
